### PR TITLE
同步购物车订单到历史订单

### DIFF
--- a/pages/confirm/confirm.js
+++ b/pages/confirm/confirm.js
@@ -1,4 +1,4 @@
-import { initialRecipient,loadCart, summary  } from '../../utils/data';
+import { initialRecipient, loadCart, summary, saveCart } from '../../utils/data';
 
 Page({
   data: { info: initialRecipient, items: [], total: 0, displayTime: '' },
@@ -10,6 +10,25 @@ Page({
     this.setData({ items, total: amount, displayTime });
   },
   submit(){
+    const { items, total } = this.data;
+    const now = new Date();
+    const id = `${now.getFullYear()}${String(now.getMonth()+1).padStart(2,'0')}${String(now.getDate()).padStart(2,'0')}${String(now.getHours()).padStart(2,'0')}${String(now.getMinutes()).padStart(2,'0')}${String(now.getSeconds()).padStart(2,'0')}`;
+    const date = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')} ${String(now.getHours()).padStart(2,'0')}:${String(now.getMinutes()).padStart(2,'0')}`;
+    const order = {
+      id,
+      date,
+      status: '待发货',
+      statusClass: 'bg-yellow-100',
+      products: items.map(x=>({ name: x.name, quantity: x.quantity, unit: x.unit })),
+      totalAmount: total
+    };
+    const orders = wx.getStorageSync('userOrders') || [];
+    orders.unshift(order);
+    wx.setStorageSync('userOrders', orders);
+
+    const cart = loadCart().filter(x=>!x.selected);
+    saveCart(cart);
+
     wx.navigateTo({ url:'/pages/success/success' });
   }
-});
+  });

--- a/pages/user/user.js
+++ b/pages/user/user.js
@@ -55,6 +55,7 @@ Page({
   
     onShow: function() {
       this.loadUserProfile();
+      this.loadOrderData();
     },
   
     // 从缓存加载用户资料
@@ -63,7 +64,8 @@ Page({
       if (userProfile) {
         this.setData({
           profileInfo: userProfile
-        });
+    });
+
       }
     },
   


### PR DESCRIPTION
## Summary
- 提交订单时保存订单数据并清理已购买商品
- 进入“我的”页面时重新加载订单以显示最新记录

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da9be44448321adf846ff0adb452a